### PR TITLE
register quest start point position

### DIFF
--- a/js/mode_distance.js
+++ b/js/mode_distance.js
@@ -29,6 +29,7 @@ function mode_distance_init(playerLocation) {
 						checkPosition(questLog, marker, markersPos, map);
 					}
 				});
+				e.positions[0] = marker;
 			});
 		});
 	});


### PR DESCRIPTION
This fixes running into the 'unassociated quest' branch in
checkPosition() and leads to starting the correct quest.

Fixes #39.
